### PR TITLE
ECS VPCを追加

### DIFF
--- a/aws/sb/vpc.tf
+++ b/aws/sb/vpc.tf
@@ -1,0 +1,7 @@
+resource "aws_vpc" "g" {
+  cidr_block       = "10.1.0.0/16"
+  instance_tenancy = "default"
+  tags = {
+    Name = "g"
+  }
+}


### PR DESCRIPTION
## 概要

<!-- 変更内容を簡潔に説明してください -->

## 変更の種類

- [ ] バグ修正
- [x] 新規リソース追加
- [ ] 既存リソースの変更
- [ ] リファクタリング
- [ ] ドキュメント更新

## 変更内容

<!-- 追加・変更・削除したリソースを記載してください -->

## 確認事項

- [x] `terraform fmt` を実行した
- [x] `terraform validate` を実行した
- [x] `terraform plan` の結果を確認した

## terraform plan の結果

<details>
<summary>plan output</summary>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_vpc.g will be created
  + resource "aws_vpc" "g" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.1.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + region                               = "ap-northeast-1"
      + tags                                 = {
          + "Name" = "g"
        }
      + tags_all                             = {
          + "Name" = "g"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

</details>

## 補足

<!-- レビュアーへの補足事項など -->
