### PR TITLE
planning-pokerのECRを追加

### DIFF
--- a/aws/sb/ecr.tf
+++ b/aws/sb/ecr.tf
@@ -1,3 +1,4 @@
+# g2
 resource "aws_ecr_repository" "g2" {
   name                 = "g2"
   image_tag_mutability = "MUTABLE"
@@ -25,5 +26,20 @@ data "aws_ecr_lifecycle_policy_document" "untagged" {
 
 resource "aws_ecr_lifecycle_policy" "g2" {
   repository = aws_ecr_repository.g2.name
+  policy     = data.aws_ecr_lifecycle_policy_document.untagged.json
+}
+
+# planning poker
+resource "aws_ecr_repository" "planning_poker" {
+  name                 = "PlanningPoker"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "planning_poker" {
+  repository = aws_ecr_repository.planning_poker.name
   policy     = data.aws_ecr_lifecycle_policy_document.untagged.json
 }


### PR DESCRIPTION
## 概要

<!-- 変更内容を簡潔に説明してください -->

## 変更の種類

- [ ] バグ修正
- [x] 新規リソース追加
- [ ] 既存リソースの変更
- [ ] リファクタリング
- [ ] ドキュメント更新

## 変更内容

<!-- 追加・変更・削除したリソースを記載してください -->

## 確認事項

- [x] `terraform fmt` を実行した
- [x] `terraform validate` を実行した
- [x] `terraform plan` の結果を確認した

## terraform plan の結果

<details>
<summary>plan output</summary>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_lifecycle_policy.planning_poker will be created
  + resource "aws_ecr_lifecycle_policy" "planning_poker" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Expire untagged images older than 14 days"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 14
                          + countType   = "sinceImagePushed"
                          + countUnit   = "days"
                          + tagStatus   = "untagged"
                        }
                    },
                ]
            }
        )
      + region      = "ap-northeast-1"
      + registry_id = (known after apply)
      + repository  = "PlanningPoker"
    }

  # aws_ecr_repository.planning_poker will be created
  + resource "aws_ecr_repository" "planning_poker" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "PlanningPoker"
      + region               = "ap-northeast-1"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags_all             = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

</details>

## 補足

<!-- レビュアーへの補足事項など -->
