### PR TITLE
ECSクラスターを追加

### DIFF
--- a/aws/sb/ecs.tf
+++ b/aws/sb/ecs.tf
@@ -1,0 +1,52 @@
+resource "aws_ecs_cluster" "planning_poker" {
+  name = "planning-poker"
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+/*
+resource "aws_security_group" "ecs_task" {
+  name   = "t1-sb-ecs-task"
+  vpc_id = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "g2" {
+  family                   = "g2"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "g2"
+      image     = "${aws_ecr_repository.g2.repository_url}:latest"
+      essential = true
+    }
+  ])
+}
+
+resource "aws_ecs_service" "g2" {
+  name            = "g2"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.g2.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.default.ids
+    security_groups  = [aws_security_group.ecs_task.id]
+    assign_public_ip = true
+  }
+}
+*/


### PR DESCRIPTION
## 概要

<!-- 変更内容を簡潔に説明してください -->

## 変更の種類

- [ ] バグ修正
- [x] 新規リソース追加
- [ ] 既存リソースの変更
- [ ] リファクタリング
- [ ] ドキュメント更新

## 変更内容

<!-- 追加・変更・削除したリソースを記載してください -->

## 確認事項

- [x] `terraform fmt` を実行した
- [x] `terraform validate` を実行した
- [x] `terraform plan` の結果を確認した

## terraform plan の結果

<details>
<summary>plan output</summary>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecs_cluster.planning_poker will be created
  + resource "aws_ecs_cluster" "planning_poker" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + name     = "planning-poker"
      + region   = "ap-northeast-1"
      + tags_all = (known after apply)

      + setting {
          + name  = "containerInsights"
          + value = "enabled"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

</details>

## 補足

<!-- レビュアーへの補足事項など -->
